### PR TITLE
Update broken links in `SI_Reference_Point/docs/README.md`

### DIFF
--- a/SI_Reference_Point/docs/README.md
+++ b/SI_Reference_Point/docs/README.md
@@ -25,7 +25,7 @@ The SI Reference Point is based on five main pillars, or knowledge graphs:
     * Decisions relating to the SI, taken by the CGPM and CIPM  (Appendix 1 of [2])
 1. **[Constants](http://si-digital-framework.org/constants)**
     * Initially the 7 defining constants of the SI (Table 1 of [2])
-1.	**[Quantities](http://si-digital-framework,org/quantities)**
+1.	**[Quantities](http://si-digital-framework.org/quantities)**
     * SI base quantities (Table 3 of [2])
     * Other example quantities (Tables 5 and 6 of [2])
     * Other quantities in the BIPM key comparison database (KCDB))
@@ -199,7 +199,7 @@ Following standard practice, the TTL files are divided between a “T-box”, sp
 The web interface at https://si-digital-framework.org/SI is designed to simplify access to the knowledge graphs for a human reader. Underpinning the web pages are a set of pre-programmed calls to the TTL files, such as (expressed as words rather than data requests) “list all the SI units”, “list all the SI prefixes”, “what is the current definition of the metre”, etc. 
 
 The same pre-programmed queries (API calls) are documented in the Swagger interface at
-[https://si-digital-framework.org/api-docs/swagger-ui/](https://si-digital-framework.org/api-docs/swagger-ui/?urls.primaryName=SI%20REFERENCE%20POIN/)
+[https://si-digital-framework.org/api-docs/swagger-ui/](https://si-digital-framework.org/api-docs/swagger-ui/?urls.primaryName=SI%20REFERENCE%20POINT)
 
 Select the service `SI REFERENCE POINT` from the drop-down menu at the top right of the screen.
 


### PR DESCRIPTION
Corrected two URLs (quantities and swagger) in the `SI_Reference_Point/docs/README.md` file.

Note: I'd also recommend adding a link to your `SI_Reference_Point/docs/README.md` file in your main `README.md` file (so that new users see a direct link to your SI Reference Point documentation on the front page of your SI Digital Framework GitHub repo), but I haven't made that change.